### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Discover modern tools for API testing, automation, and documentation with clicka
 Inspired by the “Awesome SoapUI Alternatives” concept for developers looking for faster, smarter, and collaborative SoapUI replacements 🚀.  
 
 ---
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).
 
 ## 🔥 Why Look Beyond SoapUI?
 **SoapUI** has been a go-to tool for API testing, but it can feel outdated compared to modern platforms.  


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.